### PR TITLE
Handling API Rate limit - wait for required seconds and retry request

### DIFF
--- a/hostdetection/multi_thread_hd.py
+++ b/hostdetection/multi_thread_hd.py
@@ -398,7 +398,7 @@ def parse_options():
     parser.add_option("-c", "--CHUNK_SIZE", dest="CHUNK_SIZE", default=1000,\
     help="Size of ID range chunks")
     parser.add_option("-x", "--proxy", default=None,\
-    dest="proxy", help="Proxy details e.g. 10.114.27.54:3128 OR username:password@10.10.10.2:8080")
+    dest="proxy", help="Proxy server details e.g. 10.114.27.54:3128 OR username:password@10.10.10.2:8080")
     (options, values) = parser.parse_args()
     SERVER_ROOT = options.server
     API_USERNAME = options.username
@@ -408,6 +408,13 @@ def parse_options():
     CHUNK_SIZE = int(options.CHUNK_SIZE)
     PROXY = options.proxy
 # end of parse_options
+
+def get_concurrency_limit():
+    print "Checking API concurrency limit..."
+    api_route = "/msp/about.php"
+    api_response = call_api(SERVER_ROOT + api_route, {})
+    concurrency_limit = api_response['concurrency_limit']
+    return concurrency_limit
 
 def main():
     '''
@@ -439,9 +446,7 @@ def main():
             print "Invalid proxy! please enter valid proxy details e.g. 10.114.27.54:3128 OR username:password@https://10.10.10.2:8080"
     
     try:
-        api_route = "/msp/about.php"
-        api_response = call_api(SERVER_ROOT + api_route, {})
-        concurrency_limit = api_response['concurrency_limit']
+        concurrency_limit = get_concurrency_limit()
         if concurrency_limit and NUM_ASSET_THREADS > int(concurrency_limit):
             NUM_ASSET_THREADS = int(concurrency_limit)
             print "Number of threads for assets is more than the API concurrency limit, will use %s threads instead." %concurrency_limit

--- a/hostdetection/multi_thread_hd.py
+++ b/hostdetection/multi_thread_hd.py
@@ -72,9 +72,9 @@ def call_api(api_route, params):
             rate_limit_remaining = response.info().getheader('x-ratelimit-remaining')
             to_wait_sec = response.info().getheader('x-ratelimit-towait-sec')
             if(rate_limit_remaining and int(rate_limit_remaining) <= 0 and to_wait_sec and int(to_wait_sec) > 0):
-                print "API Rate Limit("+ rate_limit +") reached, will try request again after " + to_wait_sec + " seconds."
+                print "[%s] API Rate Limit(%s) reached, will try request again after %s seconds." % (current_thread().getName(), rate_limit, to_wait_sec)
                 time.sleep(int(to_wait_sec))
-                break
+                continue
 
             if response.getcode() != 200:
                 print "[%s] Got unexpected response from API: %s" % (
@@ -91,7 +91,7 @@ def call_api(api_route, params):
                 to_wait_sec = url_error.headers.get('X-RateLimit-Towait-Sec', None)
                 
                 if rate_limit_remaining and int(rate_limit_remaining) <= 0 and to_wait_sec and int(to_wait_sec) > 0:
-                    print "API Rate Limit("+ rate_limit +") reached, will try request again after " + to_wait_sec + " seconds."
+                    print "[%s] API Rate Limit(%s) reached, will try request again after %s seconds." % (current_thread().getName(), rate_limit, to_wait_sec)
                     time.sleep(int(to_wait_sec))
                     continue
 

--- a/hostdetection/multi_thread_hd.py
+++ b/hostdetection/multi_thread_hd.py
@@ -116,6 +116,15 @@ def call_api(api_route, params):
                     print "[%s] API Rate Limit(%s) reached, will try request again after %s seconds." % (current_thread().getName(), rate_limit, to_wait_sec)
                     time.sleep(int(to_wait_sec))
                     continue
+                
+                #check for concurrency error
+                concurrency_limit = url_error.headers.get('X-Concurrency-Limit-Limit', None)
+                concurrency_limit_running = url_error.headers.get('X-Concurrency-Limit-Running', None)
+                if concurrency_limit is not None and concurrency_limit_running is not None:
+                    if int(concurrency_limit_running) >= int(concurrency_limit):
+                        print "[%s] API Concurrency Limit(%s) reached, will try request again after 30 seconds." % (current_thread().getName(), concurrency_limit)
+                        time.sleep(30)
+                        continue
 
             print "[%s] Error during request to %s: [%s] %s" % (
             current_thread().getName(), api_route,


### PR DESCRIPTION
- Handled API Rate limit. It will wait for the required wait-time and retry the request

- Added proxy support for the script.

- Handled API Concurrency Limit. It will check the API concurrency limit first and then allow the number of threads to run. Also, if concurrency limit reached while calling API then thread will sleep for 30 seconds and will retry the request
