### PR TITLE
add support to configure timeout in valiadte_image.sh script

### DIFF
--- a/containerSecurity/README.md
+++ b/containerSecurity/README.md
@@ -38,20 +38,22 @@ First thing first. Decide a criteria to evaluate your docker image. It could be 
 
 #### Executing script
 
-The script requires 4 arguments:
+The script requires 4 arguments and TOTAL_TIME optional:
+TOTAL_TIME --> if you not pass TOTAL_TIME value it will take default value as 600 second. total_time treated as script time out in case vulnerbilites processing taking more time by sensor or qualys cloud platform.
 
 1. Qualys API Server URL
 2. Qualys API Username
 3. Qualys API Password
 4. Image Id/Image Name
+5. TOTAL_TIME (Pass total time in second ex: TOTAL_TIME=300)
 
 In CI/CD pipeline, execute this script with correct arguments **after** you build your docker image, and **before** you push it to registry. Make sure you aren't deleting the image before this script executes.
 
-`./validate_image.sh ${QUALYS_API_SERVER} ${USERNAME} ${PASSWORD} ${DOCKER_IMAGE_ID}`
+`./validate_image.sh ${QUALYS_API_SERVER} ${USERNAME} ${PASSWORD} ${TOTAL_TIME}`
 
 OR
 
-`./validate_image.sh ${QUALYS_API_SERVER} ${USERNAME} ${PASSWORD} ${DOCKER_IMAGE_NAME}`
+`./validate_image.sh ${QUALYS_API_SERVER} ${USERNAME} ${PASSWORD} ${DOCKER_IMAGE_NAME} ${TOTAL_TIME}`
 
 ***It is recommended that you set those arguments as build/environment variables.*** A [sample Jenkinsfile](https://github.com/Qualys/community/blob/master/containerSecurity/Jenkinsfile_validate_image_without_plugin.groovy) is provided as well for your reference.
 

--- a/containerSecurity/README.md
+++ b/containerSecurity/README.md
@@ -38,22 +38,21 @@ First thing first. Decide a criteria to evaluate your docker image. It could be 
 
 #### Executing script
 
-The script requires 4 arguments and TOTAL_TIME optional:
-TOTAL_TIME --> if you not pass TOTAL_TIME value it will take default value as 600 second. total_time treated as script time out in case vulnerbilites processing taking more time by sensor or qualys cloud platform.
+The script requires following arguments:
 
-1. Qualys API Server URL
-2. Qualys API Username
-3. Qualys API Password
-4. Image Id/Image Name
-5. TOTAL_TIME (Pass total time in second ex: TOTAL_TIME=300)
+1. Qualys API Server URL (Required)
+2. Qualys API Username   (Required)
+3. Qualys API Password   (Required)
+4. Image Id/Image Name   (Required)
+5. Script timeout        (Optional) Pass Script timeout in seconds e.g.TIMEOUT=300. Default value is 600 seconds.
 
 In CI/CD pipeline, execute this script with correct arguments **after** you build your docker image, and **before** you push it to registry. Make sure you aren't deleting the image before this script executes.
 
-`./validate_image.sh ${QUALYS_API_SERVER} ${USERNAME} ${PASSWORD} ${TOTAL_TIME}`
+`./validate_image.sh ${QUALYS_API_SERVER} ${USERNAME} ${PASSWORD} ${TIMEOUT}`
 
 OR
 
-`./validate_image.sh ${QUALYS_API_SERVER} ${USERNAME} ${PASSWORD} ${DOCKER_IMAGE_NAME} ${TOTAL_TIME}`
+`./validate_image.sh ${QUALYS_API_SERVER} ${USERNAME} ${PASSWORD} ${DOCKER_IMAGE_NAME} ${TIMEOUT}`
 
 ***It is recommended that you set those arguments as build/environment variables.*** A [sample Jenkinsfile](https://github.com/Qualys/community/blob/master/containerSecurity/Jenkinsfile_validate_image_without_plugin.groovy) is provided as well for your reference.
 

--- a/containerSecurity/validate_image.sh
+++ b/containerSecurity/validate_image.sh
@@ -38,8 +38,8 @@ QUALYS_API_SERVER=$1
 USERNAME=$2
 PASSWORD=$3
 IMAGE=$4
-TOTAL_TIME=$5
-: ${TOTAL_TIME:=600}
+TIMEOUT=$5
+: ${TIMEOUT:=600}
 
 check_command_exists () {
 	hash $1 2>/dev/null || { echo >&2 "This script requires $1 but it's not installed. Aborting."; exit 1; }
@@ -120,19 +120,19 @@ echo "Temporarily tagging image ${IMAGE} with qualys_scan_target:${IMAGE_ID}"
 echo "Qualys Sensor will untag it after scanning. In case this is the only tag present, Sensor will not remove it."
 `docker tag ${IMAGE_ID} qualys_scan_target:${IMAGE_ID}`
 
-echo -e "\n=-=-Configured TIME_OUT in second :$TOTAL_TIME-=-=-\n"
+echo -e "\n=-=-Configured TIME_OUT in second :$TIMEOUT-=-=-\n"
 get_result
 wait_period=0
-while [ "${HTTP_CODE}" -ne "200" -o "${VULNS_AVAILABLE}" != true ] && [[ $wait_period -lt $TOTAL_TIME ]]
+while [ "${HTTP_CODE}" -ne "200" -o "${VULNS_AVAILABLE}" != true ] && [[ $wait_period -lt $TIMEOUT ]]
 do
 	echo "Retrying after 10 seconds..."
 	sleep 10s
 	wait_period=$(($wait_period+10))
 	get_result
 done
-if [ $wait_period = $TOTAL_TIME ]
+if [ $wait_period = $TIMEOUT ]
 then
-	echo "Vulnerabilities processing took  more time than configured time:$TOTAL_TIME second"
+	echo "Vulnerabilities processing took  more time than configured time:$TIMEOUT second"
 	echo "Please check the sensor logs OR QUALYS cloud platform status(https://status.qualys.com/)"
 	exit 1
 fi


### PR DESCRIPTION
User can provide timeout for **validate_image.sh** script. 
The default script timeout is 600 seconds.